### PR TITLE
Keyboard improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Please review [our security policy](../../security/policy) on how to report secu
 
 ## Credits
 
-- [Fabio Ivona](https://github.com/def:studio)
-- [BeyondCode Banners](https://banners.beyondco.de/)
+- [Fabio Ivona](https://github.com/def-studio)
+- [Andrea Marco Sartori](https://github.com/cerbero90) for his cool ideas
 - [All Contributors](../../contributors)
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "phpunit/phpunit": "^9.4",
         "spatie/laravel-ray": "^1.26",
         "spatie/pest-plugin-snapshots": "^1.1",
-        "spatie/x-ray": "^1.1"
+        "spatie/x-ray": "dev-main"
     },
     "autoload": {
         "psr-4": {

--- a/docs/content/en/features/keyboards.md
+++ b/docs/content/en/features/keyboards.md
@@ -30,6 +30,21 @@ Telegraph::message('hello world')
 ]))->send();
 ```
 
+Additinally, a keyboard can be added to a message using a closure:
+
+```php
+use DefStudio\Telegraph\Keyboard\Button;
+use DefStudio\Telegraph\Keyboard\Keyboard;
+
+Telegraph::message('hello world')
+->keyboard(function(Keyboard $keyboard){
+    return $keyboard->buttons([
+        Button::make('Delete')->action('delete')->param('id', '42'),
+        Button::make('open')->url('https://test.it'),
+    ]);
+})->send();
+```
+
 ## Buttons
 
 Each `Button` can be defined using its fluent methods and can be of two types:

--- a/docs/content/en/features/keyboards.md
+++ b/docs/content/en/features/keyboards.md
@@ -38,10 +38,9 @@ use DefStudio\Telegraph\Keyboard\Keyboard;
 
 Telegraph::message('hello world')
 ->keyboard(function(Keyboard $keyboard){
-    return $keyboard->buttons([
-        Button::make('Delete')->action('delete')->param('id', '42'),
-        Button::make('open')->url('https://test.it'),
-    ]);
+    return $keyboard
+        ->button('Delete')->action('delete')->param('id', '42')
+        ->button('open')->url('https://test.it');
 })->send();
 ```
 
@@ -67,7 +66,7 @@ Button::make('open')->url('https://test.it'),
 
 ## Keyboard Rows
 
-A keyboard will normally place one button per row, this behaviour can be customized by defining rows or by chunking buttons
+A keyboard will normally place one button per row, this behaviour can be customized by defining rows, by setting individual buttons width or by chunking buttons
 
 ### by rows
 
@@ -85,23 +84,50 @@ $keyboard = Keyboard::make()
     ]);
 ```
 
-### by chunking
+### by setting buttons width
+
+A button relative width can be set using a float number the total width percentage to be taken. Buttons will flow through the rows according to their width
+
+this example would define two buttons on the first row and a large button on the second one:
 
 ```php
 use DefStudio\Telegraph\Keyboard\Button;
 use DefStudio\Telegraph\Keyboard\Keyboard;
 
 $keyboard = Keyboard::make()
-    ->buttons([
-        Button::make('Delete')->action('delete')->param('id', '42'),
-        Button::make('Dismiss')->action('dismiss')->param('id', '42'),
-        Button::make('open')->url('https://test.it'),
-    ])->chunk(2);
+    ->button('Delete')->action('delete')->param('id', '42')->width(0.5)
+    ->button('Dismiss')->action('dismiss')->param('id', '42')->width(0.5)
+    ->button('open')->url('https://test.it');
+```
+
+**notes**
+
+ - A button default width is 1 (that's to say, the entire row width)
+ - Each width is defined as a float between 0 and 1 that represents the floating point percentage of the row taken by the button.
+ - each button will fill the current row or flow in the subsequent one if there isn't enough space left
+
+### by chunking
+
+Buttons can be authomatically chunked in rows using the `->chunk()` method.
+
+This example would return a first row of two buttons, a second row of two buttons and the last row with the remaining button.
+
+```php
+use DefStudio\Telegraph\Keyboard\Button;
+use DefStudio\Telegraph\Keyboard\Keyboard;
+
+$keyboard = Keyboard::make()
+    ->button('Delete')->action('delete')->param('id', '42')
+    ->button('Dismiss')->action('dismiss')->param('id', '42')
+    ->button('Share')->action('share')->param('id', '42')
+    ->button('Solve')->action('solve')->param('id', '42')
+    ->button('Open')->url('https://test.it')
+    ->chunk(2);
 ```
 
 ## Updating a keyboard
 
-A keyboard can be replaced by a new one by submitting its `messageId`:
+A message keyboard can be replaced by a new one by submitting its `messageId`:
 
 ```php
 Telegraph::replaceKeyboard(
@@ -115,7 +141,7 @@ Telegraph::replaceKeyboard(
 
 ## Deleting a keyboard
 
-A keyboard can be removed by submitting its `messageId`:
+A keyboard can be removed from a message by submitting its `messageId`:
 
 ```php
 Telegraph::deleteKeyboard(messageId: 1568794)->send();

--- a/src/Concerns/InteractsWithTelegram.php
+++ b/src/Concerns/InteractsWithTelegram.php
@@ -42,9 +42,9 @@ trait InteractsWithTelegram
             'parse_mode' => $this->parseMode,
         ];
 
-        if (!empty($this->keyboard)) {
+        if ($this->keyboard?->isFilled()) {
             $this->data['reply_markup'] = json_encode([
-                'inline_keyboard' => $this->keyboard,
+                'inline_keyboard' => $this->keyboard->toArray(),
             ]);
         }
     }

--- a/src/Concerns/ManagesKeyboards.php
+++ b/src/Concerns/ManagesKeyboards.php
@@ -12,15 +12,18 @@ use DefStudio\Telegraph\Telegraph;
  */
 trait ManagesKeyboards
 {
-    /** @var array<array<array<string, string>>> */
-    protected array $keyboard;
+    protected Keyboard|null $keyboard = null;
 
     /**
      * @param array<array<array<string, string>>>|Keyboard $keyboard
      */
     public function keyboard(array|Keyboard $keyboard): Telegraph
     {
-        $this->keyboard = is_array($keyboard) ? $keyboard : $keyboard->toArray();
+        if (is_array($keyboard)) {
+            $keyboard = Keyboard::fromArray($keyboard);
+        }
+
+        $this->keyboard = $keyboard;
 
         return $this;
     }

--- a/src/Concerns/ManagesKeyboards.php
+++ b/src/Concerns/ManagesKeyboards.php
@@ -15,10 +15,14 @@ trait ManagesKeyboards
     protected Keyboard|null $keyboard = null;
 
     /**
-     * @param array<array<array<string, string>>>|Keyboard $keyboard
+     * @param array<array<array<string, string>>>|Keyboard|callable(Keyboard):Keyboard $keyboard
      */
-    public function keyboard(array|Keyboard $keyboard): Telegraph
+    public function keyboard(callable|array|Keyboard $keyboard): Telegraph
     {
+        if (is_callable($keyboard)) {
+            $keyboard = $keyboard(Keyboard::make());
+        }
+
         if (is_array($keyboard)) {
             $keyboard = Keyboard::fromArray($keyboard);
         }

--- a/src/Concerns/ManagesKeyboards.php
+++ b/src/Concerns/ManagesKeyboards.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpDocMissingThrowsInspection */
+
 /** @noinspection PhpUnhandledExceptionInspection */
 
 namespace DefStudio\Telegraph\Concerns;
@@ -32,8 +34,15 @@ trait ManagesKeyboards
         return $this;
     }
 
-    public function replaceKeyboard(string $messageId, Keyboard $newKeyboard): Telegraph
+    /**
+     * @param Keyboard|callable(Keyboard):Keyboard $newKeyboard
+     */
+    public function replaceKeyboard(string $messageId, Keyboard|callable $newKeyboard): Telegraph
     {
+        if (is_callable($newKeyboard)) {
+            $newKeyboard = $newKeyboard(Keyboard::make());
+        }
+
         if ($newKeyboard->isEmpty()) {
             $replyMarkup = null;
         } else {

--- a/src/Exceptions/KeyboardException.php
+++ b/src/Exceptions/KeyboardException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DefStudio\Telegraph\Exceptions;
+
+use Exception;
+
+/**
+ * @internal
+ */
+final class KeyboardException extends Exception
+{
+    public static function undefinedMethod(string $name): KeyboardException
+    {
+        return new self("Undefined keyboard method [$name]");
+    }
+}

--- a/src/Facades/Telegraph.php
+++ b/src/Facades/Telegraph.php
@@ -2,6 +2,7 @@
 
 namespace DefStudio\Telegraph\Facades;
 
+use DefStudio\Telegraph\Keyboard\Keyboard;
 use DefStudio\Telegraph\Support\Testing\Fakes\TelegraphFake;
 use Illuminate\Support\Facades\Facade;
 
@@ -12,10 +13,11 @@ use Illuminate\Support\Facades\Facade;
  * @method static \DefStudio\Telegraph\Telegraph  message(string $message)
  * @method static \DefStudio\Telegraph\Telegraph  html(string $message)
  * @method static \DefStudio\Telegraph\Telegraph  markdown(string $message)
+ * @method static \DefStudio\Telegraph\Telegraph  keyboard(callable|array|Keyboard $keyboard)
  * @method static \DefStudio\Telegraph\Telegraph  registerWebhook()
  * @method static \DefStudio\Telegraph\Telegraph  getWebhookDebugInfo()
  * @method static \DefStudio\Telegraph\Telegraph  replyWebhook(string $callbackQueryId, string $message)
- * @method static \DefStudio\Telegraph\Telegraph  replaceKeyboard(string $messageId, array $newKeyboard)
+ * @method static \DefStudio\Telegraph\Telegraph  replaceKeyboard(string $messageId, Keyboard|callable $newKeyboard)
  * @method static \DefStudio\Telegraph\Telegraph  deleteKeyboard(string $messageId)
  * @method static \DefStudio\Telegraph\Telegraph  send()
  * @method static void  dumpSentData()

--- a/src/Keyboard/Button.php
+++ b/src/Keyboard/Button.php
@@ -21,19 +21,17 @@ class Button
         return new self($label);
     }
 
-    public function width(float $width): Button
+    public function width(float $percentage): Button
     {
-        $clone = clone $this;
-
-        $width = (int)floor($width * 100);
+        $width = (int)($percentage * 100);
 
         if ($width > 100) {
             $width = 100;
         }
 
-        $clone->width = $width;
+        $this->width = $width;
 
-        return $clone;
+        return $this;
     }
 
     public function action(string $name): static
@@ -43,23 +41,19 @@ class Button
 
     public function param(string $key, int|string $value): static
     {
-        $clone = clone $this;
-
         $key = trim($key);
         $value = trim((string) $value);
 
-        $clone->callbackData[] = "$key:$value";
+        $this->callbackData[] = "$key:$value";
 
-        return $clone;
+        return $this;
     }
 
     public function url(string $url): static
     {
-        $clone = clone $this;
+        $this->url = $url;
 
-        $clone->url = $url;
-
-        return $clone;
+        return $this;
     }
 
     /**

--- a/src/Keyboard/Keyboard.php
+++ b/src/Keyboard/Keyboard.php
@@ -154,6 +154,11 @@ class Keyboard
         return $this->buttons->isEmpty();
     }
 
+    public function isFilled(): bool
+    {
+        return !$this->isEmpty();
+    }
+
     /**
      * @return string[][][]
      */

--- a/src/Keyboard/Keyboard.php
+++ b/src/Keyboard/Keyboard.php
@@ -2,15 +2,16 @@
 
 namespace DefStudio\Telegraph\Keyboard;
 
+use DefStudio\Telegraph\Proxies\KeyboardButtonProxy;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class Keyboard
 {
     /** @var Collection<array-key, Button> */
-    private Collection $buttons;
+    protected Collection $buttons;
 
-    private function __construct()
+    public function __construct()
     {
         /* @phpstan-ignore-next-line  */
         $this->buttons = collect();
@@ -19,6 +20,14 @@ class Keyboard
     public static function make(): Keyboard
     {
         return new self();
+    }
+
+    protected function clone(): Keyboard
+    {
+        $clone = Keyboard::make();
+        $clone->buttons = $this->buttons;
+
+        return $clone;
     }
 
     /**
@@ -67,7 +76,7 @@ class Keyboard
      */
     public function row(array|Collection $buttons): Keyboard
     {
-        $clone = clone $this;
+        $clone = $this->clone();
 
         if (is_array($buttons)) {
             $buttons = collect($buttons);
@@ -84,7 +93,7 @@ class Keyboard
 
     public function chunk(int $chunk): Keyboard
     {
-        $clone = clone $this;
+        $clone = $this->clone();
 
         $buttonWidth = 1 / $chunk;
 
@@ -100,7 +109,7 @@ class Keyboard
      */
     public function buttons(array|Collection $buttons): Keyboard
     {
-        $clone = clone $this;
+        $clone = $this->clone();
 
         if (is_array($buttons)) {
             $buttons = collect($buttons);
@@ -113,7 +122,7 @@ class Keyboard
 
     public function replaceButton(string $label, Button $newButton): Keyboard
     {
-        $clone = clone $this;
+        $clone = $this->clone();
 
         $clone->buttons = $clone->buttons->map(function (Button $button) use ($newButton, $label) {
             if ($button->label() == $label) {
@@ -132,7 +141,7 @@ class Keyboard
 
     public function deleteButton(string $label): Keyboard
     {
-        $clone = clone $this;
+        $clone = $this->clone();
 
         /* @phpstan-ignore-next-line  */
         $clone->buttons = $clone->buttons->reject(fn (Button $button) => $button->label() == $label);
@@ -140,9 +149,19 @@ class Keyboard
         return $clone;
     }
 
+    public function button(string $label): KeyboardButtonProxy
+    {
+        $button = Button::make($label);
+
+        $clone = $this->clone();
+        $clone->buttons[] = $button;
+
+        return new KeyboardButtonProxy($clone, $button);
+    }
+
     public function flatten(): Keyboard
     {
-        $clone = clone $this;
+        $clone = $this->clone();
 
         $clone->buttons = $clone->buttons->map(fn (Button $button) => $button->width(1));
 

--- a/src/Models/TelegraphChat.php
+++ b/src/Models/TelegraphChat.php
@@ -69,7 +69,10 @@ class TelegraphChat extends Model
         return TelegraphFacade::chat($this)->markdown($message);
     }
 
-    public function replaceKeyboard(string $messageId, Keyboard $newKeyboard): Telegraph
+    /**
+     * @param Keyboard|callable(Keyboard):Keyboard $newKeyboard
+     */
+    public function replaceKeyboard(string $messageId, Keyboard|callable $newKeyboard): Telegraph
     {
         return TelegraphFacade::chat($this)->replaceKeyboard($messageId, $newKeyboard);
     }

--- a/src/Proxies/KeyboardButtonProxy.php
+++ b/src/Proxies/KeyboardButtonProxy.php
@@ -1,0 +1,49 @@
+<?php
+
+/** @noinspection PhpDocMissingThrowsInspection */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+namespace DefStudio\Telegraph\Proxies;
+
+use DefStudio\Telegraph\Exceptions\KeyboardException;
+use DefStudio\Telegraph\Keyboard\Button;
+use DefStudio\Telegraph\Keyboard\Keyboard;
+
+/**
+ * @internal
+ *
+ * @mixin Button
+ */
+class KeyboardButtonProxy extends Keyboard
+{
+    private Button $button;
+
+    public function __construct(Keyboard $proxyed, Button $button)
+    {
+        parent::__construct();
+        $this->button = $button;
+        $this->buttons = $proxyed->buttons;
+    }
+
+    /**
+     * @param array<array-key, mixed> $arguments
+     */
+    public function __call(string $name, array $arguments): KeyboardButtonProxy
+    {
+        if (!method_exists($this->button, $name)) {
+            throw KeyboardException::undefinedMethod($name);
+        }
+
+        $clone = $this->clone();
+
+        $clone->button->$name(...$arguments);
+
+        return $clone;
+    }
+
+    protected function clone(): KeyboardButtonProxy
+    {
+        return new self(parent::clone(), $this->button);
+    }
+}

--- a/src/Support/Testing/Fakes/TelegraphFake.php
+++ b/src/Support/Testing/Fakes/TelegraphFake.php
@@ -58,7 +58,7 @@ class TelegraphFake extends Telegraph
             'bot_token' => $this->getBotIfAvailable()->token ?? null,
             'chat_id' => $this->getChatIfAvailable()->id ?? null,
             'message' => $this->message ?? null,
-            'keyboard' => $this->keyboard ?? null,
+            'keyboard' => $this->keyboard?->toArray() ?? null,
             'parse_mode' => $this->parseMode ?? null,
         ];
     }

--- a/tests/Unit/Concerns/ManagesKeyboardsTest.php
+++ b/tests/Unit/Concerns/ManagesKeyboardsTest.php
@@ -24,6 +24,47 @@ it('can add a keyboard to a message', function () {
     });
 });
 
+it('can add a keyboard as an array', function () {
+    Http::fake();
+
+    app(Telegraph::class)
+        ->chat(make_chat())
+        ->html('foobar')
+        ->keyboard([
+            [
+                ['text' => 'foo', 'url' => 'bar'],
+            ],
+        ])
+        ->send();
+
+    Http::assertSent(function (Request $request) {
+        expect($request->url())->toMatchSnapshot();
+
+        return true;
+    });
+});
+
+it('can add a keyboard as a closure', function () {
+    Http::fake();
+
+    app(Telegraph::class)
+        ->chat(make_chat())
+        ->html('foobar')
+        ->keyboard(function ($keyboard) {
+            return $keyboard->buttons([
+                Button::make('foo')->url('bar'),
+            ]);
+        })
+        ->send();
+
+
+    Http::assertSent(function (Request $request) {
+        expect($request->url())->toMatchSnapshot();
+
+        return true;
+    });
+});
+
 it('can replace the keyboard of a message', function () {
     Http::fake();
 

--- a/tests/Unit/Concerns/ManagesKeyboardsTest.php
+++ b/tests/Unit/Concerns/ManagesKeyboardsTest.php
@@ -12,9 +12,7 @@ it('can add a keyboard to a message', function () {
     app(Telegraph::class)
         ->chat(make_chat())
         ->html('foobar')
-        ->keyboard(Keyboard::make()->buttons([
-            Button::make('foo')->url('bar'),
-        ]))
+        ->keyboard(Keyboard::make()->button('foo')->url('bar'))
         ->send();
 
     Http::assertSent(function (Request $request) {
@@ -50,11 +48,7 @@ it('can add a keyboard as a closure', function () {
     app(Telegraph::class)
         ->chat(make_chat())
         ->html('foobar')
-        ->keyboard(function ($keyboard) {
-            return $keyboard->buttons([
-                Button::make('foo')->url('bar'),
-            ]);
-        })
+        ->keyboard(fn ($keyboard) => $keyboard->button('foo')->url('bar'))
         ->send();
 
 

--- a/tests/Unit/Keyboard/KeyboardTest.php
+++ b/tests/Unit/Keyboard/KeyboardTest.php
@@ -3,7 +3,7 @@
 use DefStudio\Telegraph\Keyboard\Button;
 use DefStudio\Telegraph\Keyboard\Keyboard;
 
-test('keyboard fluent creation', function () {
+test('keyboard creation by rows', function () {
     $keyboard = Keyboard::make()
         ->row([
             Button::make('foo')
@@ -29,7 +29,7 @@ test('keyboard fluent creation', function () {
     ]);
 });
 
-test('keyboard fast fluent creation', function () {
+test('keyboard creation by buttons', function () {
     $keyboard = Keyboard::make()
         ->buttons([
             Button::make('foo')
@@ -142,5 +142,22 @@ it('can flatten its buttons', function () {
         [['text' => 'foo', 'url' => 'bar']],
         [['text' => 'foo', 'url' => 'bar']],
         [['text' => 'baz', 'callback_data' => 'action:quuz']],
+    ]);
+});
+
+it('can quickly add buttons', function () {
+    $keyboard = Keyboard::make()
+        ->button('Delete')->action('delete')->param('id', '42')
+        ->button('open')->width(0.5)->url('https://test.it')
+        ->button('foo')->width(0.5)->url('https://foo.com');
+
+    expect($keyboard)->toMatchArray([
+        [
+            ['text' => 'Delete', 'callback_data' => 'action:delete;id:42'],
+        ],
+        [
+            ['text' => 'open', 'url' => 'https://test.it'],
+            ['text' => 'foo', 'url' => 'https://foo.com'],
+        ],
     ]);
 });

--- a/tests/__snapshots__/ManagesKeyboardsTest__it_can_add_a_keyboard_as_a_closure__1.txt
+++ b/tests/__snapshots__/ManagesKeyboardsTest__it_can_add_a_keyboard_as_a_closure__1.txt
@@ -1,0 +1,1 @@
+https://api.telegram.org/bot3f3814e1-5836-3d77-904e-60f64b15df36/sendMessage?text=foobar&chat_id=-123456789&parse_mode=html&reply_markup=%7B%22inline_keyboard%22%3A%5B%5B%7B%22text%22%3A%22foo%22%2C%22url%22%3A%22bar%22%7D%5D%5D%7D

--- a/tests/__snapshots__/ManagesKeyboardsTest__it_can_add_a_keyboard_as_an_array__1.txt
+++ b/tests/__snapshots__/ManagesKeyboardsTest__it_can_add_a_keyboard_as_an_array__1.txt
@@ -1,0 +1,1 @@
+https://api.telegram.org/bot3f3814e1-5836-3d77-904e-60f64b15df36/sendMessage?text=foobar&chat_id=-123456789&parse_mode=html&reply_markup=%7B%22inline_keyboard%22%3A%5B%5B%7B%22text%22%3A%22foo%22%2C%22url%22%3A%22bar%22%7D%5D%5D%7D

--- a/tests/__snapshots__/WebhookHandlerTest__it_extracts_call_data__1.yml
+++ b/tests/__snapshots__/WebhookHandlerTest__it_extracts_call_data__1.yml
@@ -3,5 +3,6 @@ messageId: '123456'
 callbackQueryId: '159753'
 originalKeyboard:
     empty: false
+    filled: true
 data:
     action: test


### PR DESCRIPTION
This PR will add the ability to define a Keyboard using a closure:

```php
Telegraph::message('hello world')
    ->keyboard(function(Keyboard $keyboard){
        return $keyboard
            ->button('Delete')->action('delete')->param('id', '42')->width(0.5)
            ->button('Dismiss')->action('dismiss')->param('id', '42')->width(0.5)
            ->button('open')->url('https://test.it');
    })->send();
```

credits to @cerbero90 for the cool idea :sunglasses: 