### PR TITLE
fix: scoped exception on unknown commands

### DIFF
--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -9,6 +9,7 @@
 namespace DefStudio\Telegraph\Handlers;
 
 use DefStudio\Telegraph\DTO\CallbackQuery;
+use DefStudio\Telegraph\DTO\Chat;
 use DefStudio\Telegraph\DTO\Message;
 use DefStudio\Telegraph\Exceptions\TelegramWebhookException;
 use DefStudio\Telegraph\Keyboard\Keyboard;
@@ -69,9 +70,12 @@ abstract class WebhookHandler
     {
         $command = (string) $text->after('/')->before(' ')->before('@');
 
-
-
         if (!$this->canHandle($command)) {
+            if ($this->message?->chat()?->type() === Chat::TYPE_PRIVATE) {
+                report(TelegramWebhookException::invalidCommand($command));
+                $this->chat->html("Unknown command")->send();
+            }
+
             return;
         }
 

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -72,9 +72,6 @@ abstract class WebhookHandler
 
 
         if (!$this->canHandle($command)) {
-            report(TelegramWebhookException::invalidCommand($command));
-            $this->chat->html("Unknown command")->send();
-
             return;
         }
 


### PR DESCRIPTION
This PR will avoid sending an `Unknown Command` feedback in non-private chats 

fix #51 