### PR TITLE
Fix missing closing Tag in docs

### DIFF
--- a/docs/content/en/quickstart/sending-a-message.md
+++ b/docs/content/en/quickstart/sending-a-message.md
@@ -15,7 +15,7 @@ use DefStudio\Telegraph\Models\TelegraphChat;
 
 /** @var TelegraphChat $chat */
 
-$chat->html("<strong>Hello!<strong>\n\nI'm here!")->send();
+$chat->html("<strong>Hello!</strong>\n\nI'm here!")->send();
 ```
 
 <img src="screenshots/first-message.png" />


### PR DESCRIPTION
The strong closing tag was missed, resulting a bad request