### PR TITLE
Fix handler if message with document

### DIFF
--- a/src/DTO/Message.php
+++ b/src/DTO/Message.php
@@ -71,7 +71,7 @@ class Message implements Arrayable
             $message->editDate = Carbon::createFromTimestamp($data['edit_date']);
         }
 
-        $message->text = $data['text'] ?? '';
+        $message->text = $data['text'] ?? $data['caption'] ?? '';
 
         $message->protected = $data['has_protected_content'] ?? false;
 


### PR DESCRIPTION
When user sent message with attached file, handler check only `text` field. But when file attached, `text` field replaced by `caption`.