### PR TITLE
Fix: Chats for Handler

### DIFF
--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -165,17 +165,7 @@ abstract class WebhookHandler
     //---- Chat Setup
     protected function setupChat(): void
     {
-        $telegramChat = match (true) {
-            isset($this->message) => $this->message->chat(),
-            isset($this->reaction) => $this->reaction->chat(),
-            isset($this->callbackQuery) => $this->callbackQuery->message()?->chat(),
-            isset($this->chatJoinRequest) => $this->chatJoinRequest->chat(),
-            isset($this->myChatMember) => $this->myChatMember->chat(),
-            isset($this->chatMember) => $this->chatMember->chat(),
-            default => null,
-        };
-
-        assert($telegramChat !== null);
+        $telegramChat = $this->extractTelegramChat();
 
         $this->chat = $this->bot->chats()->firstOrNew([
             'chat_id' => $telegramChat->id(),
@@ -191,6 +181,23 @@ abstract class WebhookHandler
                 $this->createChat($telegramChat, $this->chat);
             }
         }
+    }
+
+    protected function extractTelegramChat(): Chat
+    {
+        $telegramChat = match (true) {
+            isset($this->message) => $this->message->chat(),
+            isset($this->reaction) => $this->reaction->chat(),
+            isset($this->callbackQuery) => $this->callbackQuery->message()?->chat(),
+            isset($this->chatJoinRequest) => $this->chatJoinRequest->chat(),
+            isset($this->myChatMember) => $this->myChatMember->chat(),
+            isset($this->chatMember) => $this->chatMember->chat(),
+            default => null,
+        };
+
+        assert($telegramChat !== null);
+
+        return $telegramChat;
     }
 
     protected function allowUnknownChat(): bool


### PR DESCRIPTION
Hi @fabio-ivona.
I saw that there are several releases without changes. I checked and saw that you made changes in chat_member and my_chat_member.
That was really nice.
I suggested making some changes so that it follows the structure.

Actually, for poll_answer, I didn't understand why you put the voterChat() input in the setupChat method. That method has no input at all.
I wanted to implement it with setupchat() like the others. But I checked that voterChat doesn't always exist, so I reverted it to the previous state.