### PR TITLE
Feat: can custom full url on a request

### DIFF
--- a/docs/13.api/1.bots.md
+++ b/docs/13.api/1.bots.md
@@ -132,6 +132,14 @@ Telegraph::store($photo, Storage::path('bot/images'), 'The Photo.jpg');
 > refer the [docs](https://core.telegram.org/bots/api#getfile) for more info.
 
 
+## `setUrl()`
+
+allows to override Full Telegram API url on a per-message basis:
+
+```php
+Telegraph::setUrl('https://my-secret-server.dev/bot{TOKEN}')->message('secret message')->send();
+```
+
 ## `setBaseUrl()`
 
 allows to override Telegram API url on a per-message basis:

--- a/docs/14.models/1.telegraph-bot.md
+++ b/docs/14.models/1.telegraph-bot.md
@@ -222,6 +222,15 @@ send back the results for an inline query
 ```
 
 
+### `setUrl()`
+
+allows to override Full Telegram API url on a per-message basis:
+
+```php
+$telegraphBot->setUrl('https://my-secret-server.dev/bot{TOKEN}');
+```
+
+
 ### `setBaseUrl()`
 
 allows to override Telegram API url on a per-message basis:

--- a/docs/14.models/2.telegraph-chat.md
+++ b/docs/14.models/2.telegraph-chat.md
@@ -295,6 +295,19 @@ use DefStudio\Telegraph\Models\TelegraphChat;
 $telegraphChat->action(ChatActions::TYPING)->send();
 ```
 
+## `setUrl()`
+
+allows to override Full Telegram API url on a per-message basis:
+
+```php
+use DefStudio\Telegraph\Models\TelegraphChat;
+
+/** @var TelegraphChat $telegraphChat */
+
+$telegraphChat->setUrl('https://my-secret-server.dev/bot{TOKEN}')->message('secret message')->send();
+```
+
+
 ## `setBaseUrl()`
 
 allows to override Telegram API url on a per-message basis:

--- a/src/Concerns/InteractsWithTelegram.php
+++ b/src/Concerns/InteractsWithTelegram.php
@@ -22,6 +22,8 @@ trait InteractsWithTelegram
 {
     protected string $endpoint;
 
+    protected string|null $url = null;
+
     protected string|null $baseUrl = null;
 
     protected string|null $httpProxy = null;
@@ -86,6 +88,15 @@ trait InteractsWithTelegram
         return SendRequestToTelegramJob::dispatch($this->getApiUrl(), $this->prepareData(), $this->files, $this->getHttpProxy())->onQueue($queue);
     }
 
+    public function setUrl(string|null $url): Telegraph
+    {
+        $telegraph = clone $this;
+
+        $telegraph->url = $url;
+
+        return $telegraph;
+    }
+
     public function setBaseUrl(string|null $url): Telegraph
     {
         $telegraph = clone $this;
@@ -130,11 +141,11 @@ trait InteractsWithTelegram
     {
         $bot = $this->getBot();
 
-        $url = $bot instanceof HasCustomUrl
-            ? $bot->getUrl()
-            : Str::of($this->getBaseUrl())
-                ->append($this->getBotToken())
-                ->toString();
+        $url = match (true) {
+            !is_null($this->url) => $this->url,
+            $bot instanceof HasCustomUrl => $bot->getUrl(),
+            default => Str::of($this->getBaseUrl())->append($this->getBotToken())->toString(),
+        };
 
         /** @phpstan-ignore-next-line */
         return Str::of($url)
@@ -147,22 +158,22 @@ trait InteractsWithTelegram
     {
         $bot = $this->getBot();
 
-        return $bot instanceof HasCustomUrl
-            ? $bot->getFilesUrl()
-            : Str::of($this->getFilesBaseUrl())
-                ->append($this->getBotToken())
-                ->toString();
+        return match (true) {
+            !is_null($this->url) => $this->url,
+            $bot instanceof HasCustomUrl => $bot->getFilesUrl(),
+            default => Str::of($this->getFilesBaseUrl())->append($this->getBotToken())->toString(),
+        };
     }
 
     public function getApiUrl(): string
     {
         $bot = $this->getBot();
 
-        $url = $bot instanceof HasCustomUrl
-            ? $bot->getUrl()
-            : Str::of($this->getBaseUrl())
-                ->append($this->getBotToken())
-                ->toString();
+        $url = match (true) {
+            !is_null($this->url) => $this->url,
+            $bot instanceof HasCustomUrl => $bot->getUrl(),
+            default => Str::of($this->getBaseUrl())->append($this->getBotToken())->toString(),
+        };
 
         /** @phpstan-ignore-next-line */
         return Str::of($url)

--- a/src/Facades/Telegraph.php
+++ b/src/Facades/Telegraph.php
@@ -57,6 +57,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \DefStudio\Telegraph\Telegraph  mediaGroup(array<int|string, array<mixed>> $media)
  * @method static \DefStudio\Telegraph\Telegraph  botUpdates()
  * @method static \DefStudio\Telegraph\Telegraph  botInfo()
+ * @method static \DefStudio\Telegraph\Telegraph  setUrl(string|null $url)
  * @method static \DefStudio\Telegraph\Telegraph  setBaseUrl(string|null $url)
  * @method static \DefStudio\Telegraph\Telegraph  setHttpProxy(string|null $proxy)
  * @method static \DefStudio\Telegraph\Telegraph  setTitle(string $title)

--- a/src/Models/TelegraphBot.php
+++ b/src/Models/TelegraphBot.php
@@ -219,6 +219,11 @@ class TelegraphBot extends Model implements Storable
         return collect($reply->json('result'))->map(fn (array $update) => TelegramUpdate::fromArray($update));
     }
 
+    public function setUrl(string|null $url): Telegraph
+    {
+        return TelegraphFacade::bot($this)->setUrl($url);
+    }
+
     public function setBaseUrl(string|null $url): Telegraph
     {
         return TelegraphFacade::bot($this)->setBaseUrl($url);

--- a/src/Models/TelegraphChat.php
+++ b/src/Models/TelegraphChat.php
@@ -284,6 +284,11 @@ class TelegraphChat extends Model implements Storable
         return TelegraphFacade::chat($this)->contact($phoneNumber, $firstName);
     }
 
+    public function setUrl(string|null $url): Telegraph
+    {
+        return TelegraphFacade::chat($this)->setUrl($url);
+    }
+
     public function setBaseUrl(string|null $url): Telegraph
     {
         return TelegraphFacade::chat($this)->setBaseUrl($url);


### PR DESCRIPTION
More implementation on #743 to customize the URL for a request.

about tests: It works like the `setBaseUrl()` and `setHttpProxy()` methods.