### PR TITLE
Add first bot onboarding tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ php artisan vendor:publish --tag="telegraph-translations"
 
 ## Usage & Documentation
 
-After a new bot is created and added to a chat/group/channel (as described [in our documentation](https://docs.defstudio.it/telegraph/v1/quickstart/new-bot)),
+After a new bot is created and added to a chat/group/channel (first-time users can follow the full [Build your first Telegram bot with Telegraph](https://docs.defstudio.it/telegraph/v1/quickstart/build-your-first-bot) tutorial),
 the `Telegraph` facade can be used to easily send messages and interact with it:
 
 ```php

--- a/docs/0.index.md
+++ b/docs/0.index.md
@@ -12,6 +12,8 @@ navigation.title: 'Introduction'
 
 #### Telegraph is a Laravel package for fluently interacting with Telegram Bots
 
+If you are setting up Telegraph for the first time, start with the full onboarding tutorial: [Build your first Telegram bot with Telegraph](11.quickstart/6.build-your-first-bot). If setup stops at the token, webhook, or chat registration step, open [Troubleshooting Telegraph onboarding](11.quickstart/7.troubleshooting).
+
 
 ```php
 Telegraph::message('hello world')

--- a/docs/11.quickstart/1.new-bot.md
+++ b/docs/11.quickstart/1.new-bot.md
@@ -9,17 +9,19 @@ Go to the [@BotFather](https://t.me/botfather) app on Telegram.
 
 Send `/newbot`, to start creating a new Bot and setting its name and username.
 
-<img src="/img/screenshots/new-bot.jpg" />
+<img src="../img/screenshots/new-bot.jpg" alt="BotFather new bot command" />
 
 Take note of the bot `token`.
 
-<img src="/img/screenshots/new-bot-token.jpg" />
+<img src="../img/screenshots/new-bot-token.jpg" alt="BotFather bot token response" />
+
+The full path from this token to a working webhook and `/start` command is covered in [Build your first Telegram bot with Telegraph](6.build-your-first-bot).
 
 ### Join groups permission
 
 To allow the bot to join Telegram groups, use the `/setjoingroups` command in @BotFather:
 
-<img src="/img/screenshots/new-bot-joingroups.jpg" />
+<img src="../img/screenshots/new-bot-joingroups.jpg" alt="BotFather join groups permission" />
 
 ### Privacy
 Now you need to choose how much the bot will be able to read from the chats. Send `/setprivacy` command to @BotFather, and select your bot privacy:
@@ -27,4 +29,4 @@ Now you need to choose how much the bot will be able to read from the chats. Sen
 - **enable**: to handle only `/` commands handling
 - **disable**: to allow the bot to read all messages sent to the chat
 
-  <img src="/img/screenshots/new-bot-setprivacy.jpg" />
+  <img src="../img/screenshots/new-bot-setprivacy.jpg" alt="BotFather privacy settings" />

--- a/docs/11.quickstart/2.register-new-bot.md
+++ b/docs/11.quickstart/2.register-new-bot.md
@@ -14,15 +14,33 @@ php artisan telegraph:new-bot
 ```
 you will be guided through a bot creation wizard that will (optionally) allow you to add a new chat and setup a bot webhook as well
 
-<img src="/img/screenshots/artisan-new-bot.jpg" />
+<img src="../img/screenshots/artisan-new-bot.jpg" alt="Telegraph new bot artisan wizard" />
+
+For an end-to-end setup with installation, BotFather token, webhook, and a test, see [Build your first Telegram bot with Telegraph](6.build-your-first-bot).
 
 ### programmatically
 
 If you are implementing a custom bot creation logic, you can create a new bot using the `TelegraphBot` model:
 
+First, store the bot token in your application environment:
+
+```dotenv
+TELEGRAM_BOT_TOKEN=123456:replace-with-your-bot-token
+```
+
+Then expose it from `config/services.php`:
+
 ```php
+'telegram' => [
+    'bot_token' => env('TELEGRAM_BOT_TOKEN'),
+],
+```
+
+```php
+use DefStudio\Telegraph\Models\TelegraphBot;
+
 $bot = TelegraphBot::create([
-    'token' => $token,
-    'name' => $name,
+    'token' => config('services.telegram.bot_token'),
+    'name' => 'Support Bot',
 ]);
 ```

--- a/docs/11.quickstart/3.setting-webhook.md
+++ b/docs/11.quickstart/3.setting-webhook.md
@@ -3,22 +3,77 @@ title: 'Setting a webhook for the bot'
 navigation.title: 'Setting a webhook'
 ---
 
+Webhooks let Telegram deliver updates to your Laravel application so the bot can respond to chat commands and button clicks. Telegram accepts only a public `https` URL, so local development needs a tunnel such as `ngrok`, Cloudflare Tunnel, Expose, or a similar HTTPS endpoint.
 
-A webhook lets your bot to answer commands issued from telegram chats and buttons inside messages
+## Local development through a tunnel
 
-### through an artisan command
+1. Start the Laravel application:
 
 ```shell
-php artisan telegraph:set-webhook {bot_id}
+php artisan serve
 ```
 
-the `bot_id` argument is mandatory if you have created more than one bot
+2. Open a public `https` tunnel to the same port. For the default `php artisan serve` setup, this is usually port `8000`:
 
-### programmatically
+```shell
+ngrok http 8000
+```
 
-A webhook can be created programmatically for a bot by calling its `registerWebhook()` method
+3. Copy the public tunnel URL and add it to `.env`. You can set the full `APP_URL`, or only the webhook domain used by Telegraph:
+
+```dotenv
+APP_URL=https://example.ngrok-free.app
+TELEGRAM_WEBHOOK_DOMAIN=https://example.ngrok-free.app
+TELEGRAPH_WEBHOOK_SECRET=your-secret-token
+```
+
+Do not commit real bot tokens or webhook secrets. For production, use a secret manager or protected environment variables.
+
+4. If the application uses cached config, clear the cache before registering the webhook:
+
+```shell
+php artisan config:clear
+```
+
+5. Register the webhook. The `{bot_id}` argument is required when the database contains more than one bot:
+
+```shell
+php artisan telegraph:set-webhook {bot_id} --secret="${TELEGRAPH_WEBHOOK_SECRET}"
+```
+
+Laravel `.env` values are not exported to the shell automatically. If you use `${TELEGRAPH_WEBHOOK_SECRET}` in a CLI command, first run `export TELEGRAPH_WEBHOOK_SECRET="your-secret-token"` in the current shell session or pass the placeholder value explicitly.
+
+Telegraph registers a route like `https://example.ngrok-free.app/telegraph/{token}/webhook` unless `TELEGRAPH_WEBHOOK_URL` is overridden. If the tunnel is restarted and the URL changes, update `.env`, run `php artisan config:clear`, and run `telegraph:set-webhook` again.
+
+If the webhook does not receive updates, the route returns `401`/`403`, or `debug-webhook` shows an old URL, use [Troubleshooting Telegraph onboarding](7.troubleshooting).
+
+## Verify registration
+
+Check which URL Telegram currently knows:
+
+```shell
+php artisan telegraph:debug-webhook {bot_id}
+```
+
+For local troubleshooting, you can temporarily enable a detailed dump of incoming webhook updates:
+
+```dotenv
+TELEGRAPH_WEBHOOK_DEBUG=true
+```
+
+Do not leave detailed webhook debug enabled in production unless it is strictly needed: payloads can contain user data.
+
+## Programmatic setup
+
+A webhook can be registered programmatically through the bot model's `registerWebhook()` method:
 
 ```php
 /** @var TelegraphBot $bot */
-$bot->registerWebhook()->send();
+$bot->registerWebhook(
+    secretToken: config('telegraph.webhook.secret'),
+)->send();
 ```
+
+The end-to-end local development flow with an HTTPS tunnel, webhook secret, and `/start` handler is covered in [Build your first Telegram bot with Telegraph](6.build-your-first-bot).
+
+For the `dropPendingUpdates`, `maxConnections`, and `secretToken` parameters, see the [webhook registration reference](../15.webhooks/2.registering-webhooks).

--- a/docs/11.quickstart/4.register-new-chat.md
+++ b/docs/11.quickstart/4.register-new-chat.md
@@ -7,7 +7,7 @@ navigation.title: 'Adding a chat'
 Associating one or more chats to a bot, it is enabled to send messages to that chat and interacting with commands
 
 > [!NOTE]
-> To get the _chat_id_ issue the `/chatid` command inside the chat after having [set up a webhook](quickstart/setting-webhook) for your bot.
+> To get the _chat_id_, send `/chatid` in the chat after [setting the webhook](3.setting-webhook) for the bot. If you are testing locally, make sure the tunnel URL is still active and matches the URL from `php artisan telegraph:debug-webhook {bot_id}`. If `/chatid` does not answer, see [Troubleshooting Telegraph onboarding](7.troubleshooting).
 
 
 ### through an artisan command
@@ -18,14 +18,19 @@ php artisan telegraph:new-chat {bot_id}
 
 the bot_id argument is mandatory if you have created more than one bot
 
+If you are setting up your first bot from installation to the first message, use [Build your first Telegram bot with Telegraph](6.build-your-first-bot).
+
 ### programmatically
 
-If you are implementing a custom bot creation logic, you can create a new chat using the `TelegraphChat` model:
+If you are implementing a custom bot creation logic, you can create a new chat from a `TelegraphBot` model:
 
 ```php
-/** @var TelegraphChat $chat */
-$chat = $telegraph_bot->chats()->create([
-    'chat_id' => $chat_id,
-    'name' => $chat_name,
+use DefStudio\Telegraph\Models\TelegraphBot;
+
+$bot = TelegraphBot::query()->firstOrFail();
+
+$chat = $bot->chats()->create([
+    'chat_id' => '123456789',
+    'name' => 'Personal chat',
 ]);
 ```

--- a/docs/11.quickstart/5.sending-a-message.md
+++ b/docs/11.quickstart/5.sending-a-message.md
@@ -9,12 +9,14 @@ After a bot and at least one chat have been set up, this package can be used to 
 ```php
 use DefStudio\Telegraph\Models\TelegraphChat;
 
-/** @var TelegraphChat $chat */
+$chat = TelegraphChat::query()
+    ->where('name', 'Personal chat')
+    ->firstOrFail();
 
-$chat->html("<strong>Hello!</strong>\n\nI'm here!")->send();
+$chat->html('<strong>Hello!</strong>')->send();
 ```
 
-<img src="/img/screenshots/first-message.png" />
+<img src="../img/screenshots/first-message.png" alt="First Telegram message sent with Telegraph" />
 
 as an alternative, messages can be formatted with markdown:
 
@@ -27,3 +29,5 @@ or markdownV2:
 ```php
 $chat->markdownV2("*Hello!*\n\nI'm here!")->send();
 ```
+
+The full flow with installation, webhook, `/start` handler, and a test is covered in [Build your first Telegram bot with Telegraph](6.build-your-first-bot).

--- a/docs/11.quickstart/6.build-your-first-bot.md
+++ b/docs/11.quickstart/6.build-your-first-bot.md
@@ -1,0 +1,311 @@
+---
+title: 'Build your first Telegram bot with Telegraph'
+navigation.title: 'First bot tutorial'
+description: 'End-to-end tutorial: install Telegraph, register a Telegram bot, set up a webhook, handle /start, send a message, and verify the flow with a test.'
+---
+
+This tutorial walks through the happy path for a first bot: install Telegraph in a Laravel application, create a bot in BotFather, register it in Telegraph, open a webhook, handle the `/start` command, register a chat, and verify the behavior with a test without making real Telegram requests.
+
+## Prerequisites
+
+You need:
+
+- A Laravel application on PHP `^8.2` with Illuminate/Laravel `^10.0`, `^11.0`, `^12.0`, or `^13.0`.
+- A public HTTPS URL for the webhook. For local development, use a tunnel such as `ngrok`, `expose`, or a similar HTTPS endpoint.
+- A Telegram account with access to [@BotFather](https://t.me/botfather).
+
+Do not commit real bot tokens, webhook secret tokens, or dumps of incoming Telegram payloads. Store secrets in `.env` or in your environment's secret manager.
+
+## 1. Install Telegraph
+
+Install the package in the host Laravel app:
+
+```shell
+composer require defstudio/telegraph
+```
+
+Publish the config and migrations:
+
+```shell
+php artisan vendor:publish --tag="telegraph-config"
+php artisan vendor:publish --tag="telegraph-migrations"
+php artisan migrate
+```
+
+The order matters: publish config and migrations first, then run migrations in the host application.
+
+Check the basic values in `.env`:
+
+```dotenv
+APP_URL=https://example.test
+TELEGRAM_WEBHOOK_DOMAIN=https://example.test
+TELEGRAPH_BOT_TOKEN=replace-with-botfather-token
+TELEGRAPH_WEBHOOK_SECRET=replace-with-a-random-secret
+```
+
+`TELEGRAPH_BOT_TOKEN` is needed only if your application reads the token from config instead of the interactive `telegraph:new-bot` wizard. `TELEGRAM_WEBHOOK_DOMAIN` is needed when the webhook URL should use a different domain than `APP_URL`. Use `TELEGRAPH_WEBHOOK_SECRET` as the value for `--secret`, so Telegram sends it in the `X-Telegram-Bot-Api-Secret-Token` header; use a random string and do not publish it in logs.
+
+If you create the bot programmatically, add the token to application config, for example in `config/services.php`:
+
+```php
+'telegram' => [
+    'bot_token' => env('TELEGRAPH_BOT_TOKEN'),
+],
+```
+
+## 2. Create a Telegram bot
+
+Open [@BotFather](https://t.me/botfather), send `/newbot`, set a name and username, then store the generated token in a safe place.
+
+<img src="../img/screenshots/new-bot-token.jpg" alt="BotFather bot token response" />
+
+Register the bot in Telegraph:
+
+```shell
+php artisan telegraph:new-bot
+```
+
+The command asks for the bot token and a readable name. If this is the first bot in the application, the wizard can also offer to create a chat and set up the webhook immediately. If you choose to set up the webhook inside the wizard, `telegraph:new-bot` accepts the same webhook options that it passes to `telegraph:set-webhook`: `--drop-pending-updates`, `--max-connections=40`, and `--secret=...`.
+
+<img src="../img/screenshots/artisan-new-bot.jpg" alt="Telegraph new bot artisan wizard" />
+
+If you already know the numeric Telegram `chat_id`, you can create the chat in the wizard immediately. If not, skip the chat at this step and get the `chat_id` later through the temporary onboarding mode for unknown chats.
+
+If you create the bot programmatically, use `TelegraphBot`:
+
+```php
+use DefStudio\Telegraph\Models\TelegraphBot;
+
+$bot = TelegraphBot::create([
+    'token' => config('services.telegram.bot_token'),
+    'name' => 'Support bot',
+]);
+```
+
+For more about creating a bot in BotFather and privacy mode, see [Creating a new bot](1.new-bot).
+
+## 3. Register the webhook
+
+Telegram delivers updates only to a public HTTPS URL. For local development, first start a tunnel and update the URL in `.env`:
+
+```dotenv
+APP_URL=https://your-tunnel.example
+TELEGRAM_WEBHOOK_DOMAIN=https://your-tunnel.example
+```
+
+After changing `.env`, clear cached config in applications that use it:
+
+```shell
+php artisan config:clear
+```
+
+Register the webhook:
+
+```shell
+php artisan telegraph:set-webhook
+```
+
+If the application has multiple bots, pass the ID of the target bot:
+
+```shell
+php artisan telegraph:set-webhook 1
+```
+
+For a safer webhook and a clean first run, pass options:
+
+```shell
+export TELEGRAPH_WEBHOOK_SECRET="replace-with-a-random-secret"
+php artisan telegraph:set-webhook 1 --drop-pending-updates --secret="${TELEGRAPH_WEBHOOK_SECRET}"
+```
+
+Laravel `.env` values are not exported to the shell automatically: if you use shell substitution like `${TELEGRAPH_WEBHOOK_SECRET}`, run `export` in the current shell session or pass an explicit placeholder value instead. In shared environments, remember that CLI options can be visible in the process list while the command runs.
+
+`telegraph:set-webhook` also accepts `--max-connections=40`; the default value matches `telegraph.webhook.max_connections`. The bot ID argument can be omitted only when the database contains exactly one `TelegraphBot`.
+
+Check the webhook state:
+
+```shell
+php artisan telegraph:debug-webhook 1
+```
+
+Do not publish command output if it contains URLs, secret-dependent diagnostics, or user data. For registration details, see [Register Webhooks](../15.webhooks/2.registering-webhooks).
+
+By default, the package route for incoming Telegram requests is `/telegraph/{token}/webhook`. The full URL is built from `APP_URL` or `TELEGRAM_WEBHOOK_DOMAIN`; the path can be changed through `TELEGRAPH_WEBHOOK_URL`, but then the same path must be reachable from the public internet and registered again in Telegram.
+
+## 4. Handle `/start`
+
+Create a custom handler in the host app:
+
+```php
+<?php
+
+namespace App\Http\Webhooks;
+
+use DefStudio\Telegraph\Handlers\WebhookHandler;
+
+class FirstBotWebhookHandler extends WebhookHandler
+{
+    public function start(): void
+    {
+        $this->chat
+            ->html('Hello! Telegraph is connected.')
+            ->send();
+    }
+}
+```
+
+Register the handler in `config/telegraph.php`:
+
+```php
+'webhook' => [
+    // ...
+    'handler' => App\Http\Webhooks\FirstBotWebhookHandler::class,
+],
+```
+
+When Telegram sends message text `/start`, `WebhookHandler` recognizes the command and calls the public `start()` method. The method must be `public`; protected and private methods are not called as commands.
+
+> [!NOTE]
+> For local diagnostics, you can temporarily enable `TELEGRAPH_WEBHOOK_DEBUG=true`, but do not log raw tokens, webhook secrets, or full Telegram payloads in shared environments.
+
+## 5. Register a chat
+
+By default, Telegraph rejects messages and commands from unknown chats through `telegraph.security.allow_messages_from_unknown_chats=false`. This means `/chatid` works only for an already registered chat or after a temporary onboarding allowance for unknown chats.
+
+If you already know the numeric Telegram `chat_id`, skip the temporary allowance and run `telegraph:new-chat` directly. If the `chat_id` is unknown, temporarily allow unknown messages in `config/telegraph.php`:
+
+```php
+'security' => [
+    // ...
+    'allow_messages_from_unknown_chats' => true,
+],
+```
+
+After changing config in applications with cached config, run:
+
+```shell
+php artisan config:clear
+```
+
+Now send this command to your bot:
+
+```text
+/chatid
+```
+
+The base `WebhookHandler` already contains a public `chatid()` method, so a custom handler that extends `WebhookHandler` can answer `/chatid` too.
+
+Register the chat:
+
+```shell
+php artisan telegraph:new-chat 1
+```
+
+If there is only one bot, the argument can be omitted:
+
+```shell
+php artisan telegraph:new-chat
+```
+
+After successful chat registration, restore the safer value:
+
+```php
+'security' => [
+    // ...
+    'allow_messages_from_unknown_chats' => false,
+],
+```
+
+Clear config cache again:
+
+```shell
+php artisan config:clear
+```
+
+Now the application can send outgoing messages to this chat:
+
+```php
+use DefStudio\Telegraph\Models\TelegraphChat;
+
+$chat = TelegraphChat::query()
+    ->where('name', 'Support chat')
+    ->firstOrFail();
+
+$chat->html("<strong>Hello!</strong>\n\nI'm here!")->send();
+```
+
+<img src="../img/screenshots/first-message.png" alt="First Telegram message sent with Telegraph" />
+
+The webhook reply to `/start` is a reaction to an incoming update. `$chat->html(...)->send()` is an outgoing message from your application, for example from a controller, command, or job.
+
+If onboarding must accept unknown chats for longer than one setup step, configure security flags deliberately and read [Handle requests from unknown chats](../15.webhooks/1.overview#handle-requests-from-unknown-chats).
+
+## 6. Test the handler
+
+In a feature test, you can verify the handler without network requests through `Telegraph::fake()`:
+
+```php
+<?php
+
+use App\Http\Webhooks\FirstBotWebhookHandler;
+use DefStudio\Telegraph\Facades\Telegraph;
+use DefStudio\Telegraph\Models\TelegraphBot;
+use DefStudio\Telegraph\Telegraph as TelegraphCore;
+use Illuminate\Http\Request;
+
+it('handles /start command', function () {
+    $bot = TelegraphBot::create([
+        'token' => 'test-bot-token',
+        'name' => 'Support Bot',
+    ]);
+
+    $chat = $bot->chats()->create([
+        'chat_id' => '-123456789',
+        'name' => 'Personal chat',
+    ]);
+
+    Telegraph::fake();
+
+    app(FirstBotWebhookHandler::class)->handle(
+        Request::create('', 'POST', [
+            'message' => [
+                'message_id' => 123456,
+                'chat' => [
+                    'id' => (int) $chat->chat_id,
+                    'type' => 'private',
+                    'username' => 'john-smith',
+                ],
+                'text' => '/start',
+                'date' => 1646516736,
+            ],
+        ]),
+        $bot,
+    );
+
+    Telegraph::assertSent('Hello! Telegraph is connected.');
+    Telegraph::assertSentData(TelegraphCore::ENDPOINT_MESSAGE, [
+        'chat_id' => $chat->chat_id,
+        'text' => 'Hello! Telegraph is connected.',
+    ]);
+});
+```
+
+This test creates a persisted `TelegraphBot` and the first known `TelegraphChat`, enables fake mode before handling the webhook, and verifies that the handler sends a message to the chat from the incoming update. `Telegraph::fake()` does not make real Telegram requests; for manual debugging, inspect sent payloads with `Telegraph::dumpSentData()`.
+
+For more about fake assertions, see [Fake Telegram interaction](../17.testing/1.fake) and [Assertions](../17.testing/2.assertions).
+
+## Troubleshooting
+
+Detailed diagnostics with symptoms, likely causes, and check/fix steps are available in [Troubleshooting Telegraph onboarding](7.troubleshooting).
+
+| Symptom | Fix |
+| --- | --- |
+| `telegraph:new-bot` does not accept the token | Copy the token from BotFather again and do not add spaces or quotes. Do not paste the token in docs, tickets, or logs. |
+| The webhook is not called locally | Make sure the tunnel URL is public, uses HTTPS, and matches `APP_URL` or `TELEGRAM_WEBHOOK_DOMAIN`. After changing the tunnel URL, run `php artisan config:clear` and then `telegraph:set-webhook` again. |
+| Telegram keeps sending old updates | Run `php artisan telegraph:set-webhook 1 --drop-pending-updates`. |
+| The application has multiple bots | Pass `{bot_id}` to `telegraph:set-webhook`, `telegraph:debug-webhook`, and `telegraph:new-chat`. |
+| `/start` does not call the method | Check that the handler is registered in `config('telegraph.webhook.handler')`, the method is named `start`, it is `public`, and config cache is cleared. |
+| The chat is not found | If `chat_id` is unknown, temporarily enable `allow_messages_from_unknown_chats`, get the ID through `/chatid`, register the chat through `telegraph:new-chat`, and restore the safer config. |
+| `telegraph:debug-webhook` shows an old URL | Clear config cache, update `APP_URL`/`TELEGRAM_WEBHOOK_DOMAIN`, and register the webhook again. |
+
+The next step after the happy path is to add real commands, keyboards, or callback handling. Start with [Webhook request types](../15.webhooks/4.webhook-request-types) and [Message Keyboards](../12.features/3.keyboards).

--- a/docs/11.quickstart/7.troubleshooting.md
+++ b/docs/11.quickstart/7.troubleshooting.md
@@ -1,0 +1,233 @@
+---
+title: 'Troubleshooting Telegraph onboarding'
+navigation.title: 'Troubleshooting'
+description: 'Common checks for first bot setup issues: bot token, webhook delivery, secret token, chat registration, config cache and local tunnels.'
+---
+
+Use this page when the first bot tutorial stops before the bot can answer `/start` or send the first message. The checks below use placeholder values only; do not publish real bot tokens, webhook secret tokens, Telegram headers or full user payloads in issues, logs or screenshots.
+
+## Bot token is rejected
+
+### Symptoms
+
+- `telegraph:new-bot` does not create a bot.
+- Telegram API returns an unauthorized or invalid token response.
+- A bot record was created with a copied token, but API calls fail.
+
+### Likely cause
+
+The token copied from BotFather is incomplete, has extra spaces or quotes, or was revoked.
+
+### Check or fix
+
+Copy the token from [@BotFather](https://t.me/botfather) again and paste it without surrounding quotes. If the token was revoked, create a new token in BotFather and update the stored `TelegraphBot` record or rerun:
+
+```shell
+php artisan telegraph:new-bot
+```
+
+For programmatic setup, keep the token in `.env` and expose it through application config:
+
+```dotenv
+TELEGRAPH_BOT_TOKEN=123456:ABC-replace-with-your-bot-token
+```
+
+```php
+'telegram' => [
+    'bot_token' => env('TELEGRAPH_BOT_TOKEN'),
+],
+```
+
+## Webhook is not receiving updates
+
+### Symptoms
+
+- `/start` or `/chatid` produces no response.
+- `telegraph:debug-webhook` shows an empty, old or unexpected URL.
+- Telegram reports delivery errors or keeps increasing `pending_update_count`.
+- Your tunnel inspector does not show incoming `POST` requests.
+
+### Likely cause
+
+Telegram cannot reach the current public HTTPS URL, or the webhook was not registered again after the local tunnel URL changed.
+
+### Check or fix
+
+Start the Laravel app and tunnel to the same port:
+
+```shell
+php artisan serve
+```
+
+```shell
+ngrok http 8000
+```
+
+Set the public HTTPS URL in `.env`:
+
+```dotenv
+APP_URL=https://example.ngrok-free.app
+TELEGRAM_WEBHOOK_DOMAIN=https://example.ngrok-free.app
+```
+
+Clear cached config, register the webhook again, then inspect Telegram's current webhook state:
+
+```shell
+php artisan config:clear
+php artisan telegraph:set-webhook {bot_id}
+php artisan telegraph:debug-webhook {bot_id}
+```
+
+For local-only diagnostics you can temporarily enable webhook payload logging:
+
+```dotenv
+TELEGRAPH_WEBHOOK_DEBUG=true
+```
+
+Disable it outside local troubleshooting because webhook payloads can contain user data.
+
+If stale updates are not useful during setup, drop them on the next registration:
+
+```shell
+php artisan telegraph:set-webhook {bot_id} --drop-pending-updates
+```
+
+## Webhook secret or middleware rejects requests
+
+### Symptoms
+
+- The tunnel inspector shows incoming `POST` requests, but Laravel returns `401` or `403`.
+- The bot works without custom middleware but fails after adding secret validation.
+- Telegram keeps retrying the same update.
+
+### Likely cause
+
+The secret passed to Telegram with `--secret` does not match the value expected by your middleware, or a reverse proxy / CSRF rule blocks the webhook route.
+
+### Check or fix
+
+Store the expected secret and register the webhook with the same value:
+
+```dotenv
+TELEGRAPH_WEBHOOK_SECRET=your-secret-token
+```
+
+```shell
+export TELEGRAPH_WEBHOOK_SECRET="your-secret-token"
+php artisan telegraph:set-webhook {bot_id} --secret="${TELEGRAPH_WEBHOOK_SECRET}"
+```
+
+Laravel `.env` does not export variables into the shell automatically. If you use `${TELEGRAPH_WEBHOOK_SECRET}` in a CLI command, run `export` in the current shell session first or pass a placeholder value explicitly.
+
+If you validate `X-Telegram-Bot-Api-Secret-Token`, keep that logic in middleware configured through `telegraph.webhook.middleware` or in your own request handling layer. Do not log the header value in shared environments.
+
+## Chat registration fails or `/chatid` does not answer
+
+### Symptoms
+
+- `/chatid` does not return the chat ID.
+- `/start` does not reach your handler in a new chat.
+- `telegraph:new-chat` creates no usable chat because the `chat_id` is unknown.
+
+### Likely cause
+
+By default, Telegraph rejects messages and commands from chats that are not already stored as `TelegraphChat` models. Group privacy mode or missing group permissions can also hide messages from the bot.
+
+### Check or fix
+
+If you already know the numeric Telegram `chat_id`, register it directly:
+
+```shell
+php artisan telegraph:new-chat {bot_id}
+```
+
+If you do not know the `chat_id`, temporarily allow unknown messages while onboarding:
+
+```php
+'security' => [
+    'allow_messages_from_unknown_chats' => true,
+],
+```
+
+Then clear config cache, send `/chatid`, register the returned ID, and restore the safer default:
+
+```shell
+php artisan config:clear
+php artisan telegraph:new-chat {bot_id}
+```
+
+```php
+'security' => [
+    'allow_messages_from_unknown_chats' => false,
+],
+```
+
+For groups, check BotFather privacy mode and join permissions before debugging the application handler.
+
+## Config cache is stale
+
+### Symptoms
+
+- `.env` contains the new tunnel URL or secret, but `debug-webhook` still shows old values.
+- Changing `TELEGRAM_WEBHOOK_DOMAIN`, `TELEGRAPH_WEBHOOK_URL` or `TELEGRAPH_WEBHOOK_SECRET` appears to have no effect.
+- The app works locally in one process but not through the webhook route.
+
+### Likely cause
+
+Laravel is using cached config from before the `.env` change.
+
+### Check or fix
+
+Clear config cache before registering the webhook again:
+
+```shell
+php artisan config:clear
+php artisan telegraph:set-webhook {bot_id} --secret=your-secret-token
+php artisan telegraph:debug-webhook {bot_id}
+```
+
+If the webhook path itself changed through `TELEGRAPH_WEBHOOK_URL`, also verify the route exists:
+
+```shell
+php artisan route:list
+```
+
+## Local tunnel or dev server is down
+
+### Symptoms
+
+- The tunnel URL opens an error page.
+- Telegram reports connection refused, timeout or bad gateway.
+- The tunnel inspector shows requests to the wrong local port.
+
+### Likely cause
+
+The Laravel dev server is not running, the tunnel points to the wrong port, the URL is not HTTPS, or the free tunnel URL changed after restart.
+
+### Check or fix
+
+Start the app and tunnel again, then copy the fresh HTTPS URL:
+
+```shell
+php artisan serve
+```
+
+```shell
+ngrok http 8000
+```
+
+Update `APP_URL` or `TELEGRAM_WEBHOOK_DOMAIN`, clear config cache and register the webhook again:
+
+```shell
+php artisan config:clear
+php artisan telegraph:set-webhook {bot_id}
+php artisan telegraph:debug-webhook {bot_id}
+```
+
+For route-level failures, compare the registered URL with the default path:
+
+```text
+/telegraph/{token}/webhook
+```
+
+If you changed `TELEGRAPH_WEBHOOK_URL`, the same path must be reachable from the public tunnel URL and registered again in Telegram.

--- a/docs/13.api/1.bots.md
+++ b/docs/13.api/1.bots.md
@@ -87,13 +87,14 @@ you can use the method parameters to customize the webhook settings:
 - `dropPendingUpdates`: drops pending updates from telegram
 - `maxConnections`: maximum allowed simultaneous connections to the webhook (defaults to 40)
 - `secretToken`: secret token to be sent in a `X-Telegram-Bot-Api-Secret-Token` header to verify the authenticity of the webhook
+- `allowedUpdates`: list of event types for which the webhook should fire
 
 ## `unregisterWebhook()`
 
 unregister a webhook for the active bot
 
 ```php
-Telegraph::registerWebhook()->send();
+Telegraph::unregisterWebhook()->send();
 ```
 
 

--- a/docs/15.webhooks/1.overview.md
+++ b/docs/15.webhooks/1.overview.md
@@ -5,8 +5,10 @@ navigation.title: 'Overview'
 
 Telegram bots can interact with chats and users through a webhook system that enables it to be updated about chats changes, new commands and user interactions without continuously polling Telegram APIs for updates.
 
+For public `https` URL setup, local tunnels, secret tokens, and checks with `telegraph:debug-webhook`, see [Register Webhooks](2.registering-webhooks). For first-bot setup diagnostics, see [Troubleshooting Telegraph onboarding](../11.quickstart/7.troubleshooting).
+
 > [!WARNING]
-> By default webhooks can handle incoming requests from "known" chats (the one stored in database as TelegraphChat models) and will reject all others. In order to handle unknown chats see [below](webhooks/overview#handle-requests-from-unknown-chats)
+> By default webhooks can handle incoming requests from "known" chats (the one stored in database as TelegraphChat models) and will reject all others. In order to handle unknown chats see [below](#handle-requests-from-unknown-chats)
 
 
 ## Default Handler
@@ -104,4 +106,3 @@ class MyWebhookHandler extends \DefStudio\Telegraph\Handlers\WebhookHandler
     }
 }
 ```
-

--- a/docs/15.webhooks/2.registering-webhooks.md
+++ b/docs/15.webhooks/2.registering-webhooks.md
@@ -3,38 +3,192 @@ title: 'Register Webhooks'
 navigation.title: 'Register Webhooks'
 ---
 
-In order to receive Telegram updates through a webhook, it has to be registered to a specific bot. This can be accomplished both programmatically and through an artisan command
+To receive Telegram updates through a webhook, register a public `https` URL for a specific bot. For the fast onboarding path, see the [quickstart webhook step](../11.quickstart/3.setting-webhook); this page covers registration parameters and diagnostics in more detail. For symptom-based first-bot diagnostics, see [Troubleshooting Telegraph onboarding](../11.quickstart/7.troubleshooting).
 
-### artisan command
+## Public URL and local tunnel
 
-You can register a webhook calling the `telegraph:set-webhook` artisan command:
-
-```shell
-php artisan telegraph:set-webhook
-```
-
-some options are available in order to customize the webhook settings, refer to [bots documentation](../14.models/1.telegraph-bot#registerWebhook) for more info:
+Telegram must be able to reach your application from the public internet. In production this is usually your application domain; in local development it is a temporary `https` tunnel:
 
 ```shell
-php artisan telegraph:set-webhook --drop-pending-updates --max-connections=100 --secret=super_secret_token
+ngrok http 8000
 ```
 
-### programmatically
+Copy the public tunnel URL and configure one of these values:
 
-if you are implementing a custom bot management logic, you can register a webhok using the `TelegraphBot` model:
+```dotenv
+APP_URL=https://example.ngrok-free.app
+TELEGRAM_WEBHOOK_DOMAIN=https://example.ngrok-free.app
+```
+
+`TELEGRAM_WEBHOOK_DOMAIN` sets `telegraph.webhook.domain` and is used when registering the webhook instead of the domain from `APP_URL`. This is useful when the rest of the application still uses a local `APP_URL`, but Telegram needs a public route.
+
+If you use `php artisan config:cache`, clear cached config after changing `.env`:
+
+```shell
+php artisan config:clear
+```
+
+## Route URL
+
+Telegraph registers a Laravel route named `telegraph.webhook`. The default path is:
+
+```text
+/telegraph/{token}/webhook
+```
+
+With the default config, the full URL looks like this:
+
+```text
+https://example.ngrok-free.app/telegraph/{token}/webhook
+```
+
+You can change the path through `TELEGRAPH_WEBHOOK_URL` (`telegraph.webhook.url`) or disable the route by setting the config value to `null`:
+
+```dotenv
+TELEGRAPH_WEBHOOK_URL=/telegram/{token}/webhook
+```
+
+If the route changes, verify that middleware and the reverse proxy allow `POST` requests to the new URL.
+
+## Secret token
+
+The Telegram Bot API lets you pass a `secret_token` when registering a webhook. Telegram sends that value in the `X-Telegram-Bot-Api-Secret-Token` header on later webhook requests.
+
+Store the value in `.env` and do not publish it in issues, logs, or screenshots:
+
+```dotenv
+TELEGRAPH_WEBHOOK_SECRET=your-secret-token
+```
+
+For CLI registration, pass the secret explicitly:
+
+```shell
+php artisan telegraph:set-webhook {bot_id} --secret="${TELEGRAPH_WEBHOOK_SECRET}"
+```
+
+For programmatic registration, pass `secretToken`:
 
 ```php
 /** @var DefStudio\Telegraph\Models\TelegraphBot $telegraphBot */
 
-$telegraphBot->registerWebhook()->send();
+$telegraphBot->registerWebhook(
+    secretToken: config('telegraph.webhook.secret'),
+)->send();
 ```
 
-some options are available in order to customize the webhook settings, refer to [bots documentation](../14.models/1.telegraph-bot#registerWebhook) for more info:
+> [!NOTE]
+> Telegraph sends `secret_token` to Telegram during registration. If your application must enforce inbound validation of the `X-Telegram-Bot-Api-Secret-Token` header, add that check to middleware from `telegraph.webhook.middleware` or to your own request handling layer.
+
+## Artisan command
+
+Register a webhook with:
+
+```shell
+php artisan telegraph:set-webhook {bot_id}
+```
+
+`{bot_id}` can be omitted when the system has only one bot. Available options:
+
+```shell
+php artisan telegraph:set-webhook {bot_id} \
+    --drop-pending-updates \
+    --max-connections=100 \
+    --secret=your-secret-token
+```
+
+- `--drop-pending-updates` removes pending updates on Telegram when changing the webhook.
+- `--max-connections` sets the maximum allowed simultaneous connections. The default comes from `telegraph.webhook.max_connections`.
+- `--secret` passes Telegram the `secret_token`.
+
+## Allowed updates
+
+`telegraph.webhook.allowed_updates` can be set in config when the bot should receive only some update types. A `null` value keeps Telegram's default behavior: all update types except some opt-in events such as `chat_member`, `message_reaction`, and `message_reaction_count`.
+
+Example config:
+
+```php
+'webhook' => [
+    'allowed_updates' => ['message', 'callback_query'],
+],
+```
+
+## Programmatic registration
+
+If the application has its own bot management logic, register the webhook through `TelegraphBot`:
+
+```php
+/** @var DefStudio\Telegraph\Models\TelegraphBot $telegraphBot */
+
+$telegraphBot->registerWebhook(
+    dropPendingUpdates: true,
+    maxConnections: 100,
+    secretToken: 'your-secret-token',
+)->send();
+```
+
+For the method signature, see the [TelegraphBot documentation](../14.models/1.telegraph-bot#registerWebhook).
 
 > [!WARNING]
-> Manual updates polling is not available if a webhook is set up for the bot. Webhook should be remove first using its [unregisterWebhook](3.deleting-webhooks#programmatically) method
+> Manual updates polling is not available while a bot has a configured webhook. First remove the webhook through the [unregisterWebhook](3.deleting-webhooks#programmatically) method.
 
+## Check with the debug command
 
-## Routes
+After registration, check the webhook state on Telegram:
 
-Telegraph register a route to handle webhook messages. By default, the URL is: `https://<server_domain>/telegraph/{token}/webhook`, but it can be customized in [telegraph.php config](installation#Configuration) file (`webhook.url`) or entirely disabled (by setting its value to `null`) 
+```shell
+php artisan telegraph:debug-webhook {bot_id}
+```
+
+The command shows Telegram webhook diagnostics such as `url`, `pending_update_count`, `last_error_date`, `last_error_message`, `max_connections`, and `allowed_updates` when Telegram returns those fields. This is Telegram delivery diagnostics, not a dump of the incoming Laravel request.
+
+For runtime diagnostics, use:
+
+- `php artisan telegraph:debug-webhook {bot_id}` for the webhook state in Telegram.
+- `storage/logs/laravel.log` for handler, middleware, and application code errors.
+- The tunnel inspector (`ngrok` web UI or similar) to check incoming `POST` requests.
+
+Do not paste real bot tokens, webhook secrets, Telegram headers, or full user payloads into public issues or shared logs.
+
+## Troubleshooting local development
+
+The full onboarding troubleshooting guide is available in [Troubleshooting Telegraph onboarding](../11.quickstart/7.troubleshooting). This section keeps the webhook-specific checks short.
+
+### Telegram rejects the URL
+
+Make sure the webhook URL starts with `https://`. If the route does not use `TELEGRAM_WEBHOOK_DOMAIN`, Laravel must generate a secure URL from `APP_URL`.
+
+### Tunnel URL changed after restart
+
+Free tunnel URLs often change after restart. Update `APP_URL` or `TELEGRAM_WEBHOOK_DOMAIN`, run `php artisan config:clear`, then run `telegraph:set-webhook` again.
+
+### `debug-webhook` shows an old URL
+
+The config cache probably still contains old env values, or the webhook was not registered again after changing the tunnel. Run:
+
+```shell
+php artisan config:clear
+php artisan telegraph:set-webhook {bot_id} --secret=your-secret-token
+php artisan telegraph:debug-webhook {bot_id}
+```
+
+### Route returns `404`
+
+Check `TELEGRAPH_WEBHOOK_URL` and the published config. By default the route should be `/telegraph/{token}/webhook`; if you override the path, the same path must be registered in Telegram. Also check `php artisan route:list` in the host application.
+
+### Route returns `401` or `403`
+
+Check middleware from `telegraph.webhook.middleware`, CSRF/external access rules, the reverse proxy, and any custom `X-Telegram-Bot-Api-Secret-Token` validation. The secret in Telegram registration and the expected middleware value must match.
+
+### `/chatid` does not answer in a new chat
+
+By default the webhook handler accepts requests only from known `TelegraphChat` models and can reject unknown chats. To obtain the first `chat_id`, use the default handler flow from the [overview](1.overview#default-handler) or configure the unknown-chat security options deliberately.
+
+### Pending updates arrive after changing the webhook
+
+If old updates are no longer useful, register the webhook again with `--drop-pending-updates`:
+
+```shell
+php artisan telegraph:set-webhook {bot_id} --drop-pending-updates --secret=your-secret-token
+```
+
+If you need to remove the webhook entirely, use `telegraph:unset-webhook`.

--- a/docs/15.webhooks/4.webhook-request-types.md
+++ b/docs/15.webhooks/4.webhook-request-types.md
@@ -88,6 +88,30 @@ class CustomWebhookHandler extends WebhookHandler
 }
 ```
 
+For example, the `/start` command is handled by a public `start()` method:
+
+```php
+namespace App\Http\Webhooks;
+
+use DefStudio\Telegraph\Handlers\WebhookHandler;
+
+class MyWebhookHandler extends WebhookHandler
+{
+    public function start(): void
+    {
+        $this->chat->html('Welcome!')->send();
+    }
+}
+```
+
+Register the custom handler in `config/telegraph.php`:
+
+```php
+'webhook' => [
+    'handler' => App\Http\Webhooks\MyWebhookHandler::class,
+],
+```
+
 optionally, the handler method can receive the command parameters:
 
 ```php

--- a/docs/17.testing/1.fake.md
+++ b/docs/17.testing/1.fake.md
@@ -18,6 +18,22 @@ Telegraph::assertSent('Hello devs!');
 
 ```
 
+For a webhook command flow, call `Telegraph::fake()` before the handler and assert the fake payload after handling. The first-bot tutorial has a complete `/start` example with a persisted `TelegraphBot`, a known `TelegraphChat`, and no real Telegram requests: [Build your first Telegram bot with Telegraph](../11.quickstart/6.build-your-first-bot#6-test-the-handler).
+
+```php
+use DefStudio\Telegraph\Facades\Telegraph;
+use DefStudio\Telegraph\Telegraph as TelegraphCore;
+
+Telegraph::fake();
+
+// Handle the webhook request for /start...
+
+Telegraph::assertSentData(TelegraphCore::ENDPOINT_MESSAGE, [
+    'chat_id' => '-123456789',
+    'text' => 'Hello! Telegraph is connected.',
+]);
+```
+
 ### Custom responses
 
 If needed for testing purpose, the `::fake()` helper can accept an array of responses to be returned for each endpoint call:

--- a/docs/17.testing/2.assertions.md
+++ b/docs/17.testing/2.assertions.md
@@ -45,6 +45,8 @@ Telegraph::assertSentData(
 );
 ```
 
+For an end-to-end webhook command example, see the first-bot testing path: [Build your first Telegram bot with Telegraph](../11.quickstart/6.build-your-first-bot#6-test-the-handler). It combines `Telegraph::fake()`, `Telegraph::assertSent()`, and `Telegraph::assertSentData()` to verify that `/start` answers in the expected first chat.
+
 ## assertSentFiles
 
 asserts that the given files were sent to a Telegram API endpoint
@@ -94,4 +96,3 @@ asserts that a webhook reply has been sent with the given text
 ```php
 Telegraph::assertRepliedWebhook('task completed');
 ```
-

--- a/docs/2.installation.md
+++ b/docs/2.installation.md
@@ -5,24 +5,25 @@ menuTitle: 'Installation'
 
 You can install the package via composer:
 
-``` bash
+```bash
 composer require defstudio/telegraph
 ```
 
 ## Set up
 
-In order to work, Telegraph needs you to run its migrations:
+In order to work, Telegraph needs you to publish and run its migrations:
 
 ```bash
 php artisan vendor:publish --tag="telegraph-migrations"
 ```
+
 ```bash
 php artisan migrate
 ```
 
 ## Configuration
 
-You can publish the config file with:
+You can optionally publish the config file with:
 
 ```bash
 php artisan vendor:publish --tag="telegraph-config"
@@ -205,4 +206,4 @@ return [
 
 ## New bot creation
 
-In order to interact with Telegram, a new bot should be created and associated with a Telegram bot. Follow the  [quickstart guide](quickstart/new-bot) for an overview of this.
+In order to interact with Telegram, a new bot should be created and associated with a Telegram bot. Follow the [Build your first Telegram bot with Telegraph](11.quickstart/6.build-your-first-bot) tutorial for the full onboarding flow.

--- a/tests/Feature/Docs/FirstBotTutorialTest.php
+++ b/tests/Feature/Docs/FirstBotTutorialTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use DefStudio\Telegraph\Facades\Telegraph;
+use DefStudio\Telegraph\Handlers\WebhookHandler;
+use DefStudio\Telegraph\Models\TelegraphBot;
+use DefStudio\Telegraph\Telegraph as TelegraphCore;
+use Illuminate\Http\Request;
+
+class FirstBotTutorialWebhookHandler extends WebhookHandler
+{
+    public function start(): void
+    {
+        $this->chat
+            ->html('Hello! Telegraph is connected.')
+            ->send();
+    }
+}
+
+it('handles the /start command from the tutorial', function () {
+    $bot = TelegraphBot::create([
+        'token' => 'test-bot-token',
+        'name' => 'Support Bot',
+    ]);
+
+    $chat = $bot->chats()->create([
+        'chat_id' => '-123456789',
+        'name' => 'Personal chat',
+    ]);
+
+    Telegraph::fake();
+
+    app(FirstBotTutorialWebhookHandler::class)->handle(
+        Request::create('', 'POST', [
+            'message' => [
+                'message_id' => 123456,
+                'chat' => [
+                    'id' => (int) $chat->chat_id,
+                    'type' => 'private',
+                    'username' => 'john-smith',
+                ],
+                'text' => '/start',
+                'date' => 1646516736,
+            ],
+        ]),
+        $bot,
+    );
+
+    Telegraph::assertSent('Hello! Telegraph is connected.');
+    Telegraph::assertSentData(TelegraphCore::ENDPOINT_MESSAGE, [
+        'chat_id' => $chat->chat_id,
+        'text' => 'Hello! Telegraph is connected.',
+    ], exact: false);
+});

--- a/tests/Feature/DocumentationCodeSnippetsTest.php
+++ b/tests/Feature/DocumentationCodeSnippetsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use DefStudio\Telegraph\Facades\Telegraph;
+use DefStudio\Telegraph\Handlers\WebhookHandler;
+use DefStudio\Telegraph\Models\TelegraphBot;
+use DefStudio\Telegraph\Models\TelegraphChat;
+use DefStudio\Telegraph\Telegraph as TelegraphCore;
+
+it('documents the programmatic bot chat and message flow', function () {
+    config()->set('services.telegram.bot_token', 'test-bot-token');
+
+    $bot = TelegraphBot::create([
+        'token' => config('services.telegram.bot_token'),
+        'name' => 'Support Bot',
+    ]);
+
+    $chat = $bot->chats()->create([
+        'chat_id' => '123456789',
+        'name' => 'Personal chat',
+    ]);
+
+    Telegraph::fake();
+
+    $chat = TelegraphChat::query()
+        ->where('name', 'Personal chat')
+        ->firstOrFail();
+
+    $chat->html('<strong>Hello!</strong>')->send();
+
+    expect($bot)
+        ->toBeInstanceOf(TelegraphBot::class)
+        ->name->toBe('Support Bot')
+        ->and($chat)
+        ->toBeInstanceOf(TelegraphChat::class)
+        ->chat_id->toBe('123456789');
+
+    Telegraph::assertSent('<strong>Hello!</strong>');
+    Telegraph::assertSentData(TelegraphCore::ENDPOINT_MESSAGE, [
+        'chat_id' => $chat->chat_id,
+        'text' => '<strong>Hello!</strong>',
+    ]);
+});
+
+it('documents handling the start command with a custom webhook handler', function () {
+    $bot = TelegraphBot::create([
+        'token' => 'test-bot-token',
+        'name' => 'Support Bot',
+    ]);
+
+    $bot->chats()->create([
+        'chat_id' => '-123456789',
+        'name' => 'Personal chat',
+    ]);
+
+    Telegraph::fake();
+
+    $handler = new class () extends WebhookHandler {
+        public function start(): void
+        {
+            $this->chat->html('Welcome!')->send();
+        }
+    };
+
+    $handler->handle(webhook_command('/start'), $bot);
+
+    Telegraph::assertSent('Welcome!');
+    Telegraph::assertSentData(TelegraphCore::ENDPOINT_MESSAGE, [
+        'chat_id' => '-123456789',
+        'text' => 'Welcome!',
+    ]);
+});


### PR DESCRIPTION
## Summary

- Adds an end-to-end first bot onboarding tutorial covering installation, BotFather setup, webhook registration, /start handling, chat registration, first message sending, and tests.
- Adds a dedicated troubleshooting page for token, webhook, secret, chat registration, config cache, and local tunnel issues.
- Links the tutorial and troubleshooting guide from quickstart, webhook, and testing documentation.
- Keeps the new user-facing documentation in English and reuses existing screenshots with relative paths and alt text.

## Validation

- composer validate
- vendor/bin/pest tests/Feature/Docs/FirstBotTutorialTest.php tests/Feature/DocumentationCodeSnippetsTest.php
- git diff --cached --check
- checked that README, docs, and touched feature tests contain no Cyrillic text

Closes #232