### PR TITLE
fix: tolerate empty file storage payloads

### DIFF
--- a/docs/16.storage/1.entities_storage.md
+++ b/docs/16.storage/1.entities_storage.md
@@ -114,6 +114,8 @@ value in a `/[laravel local disk path]/telegraph/User/<telegraph_user_id>.json` 
 $telegraphUser->storage('file')->put('name', 'Daniele');
 ```
 
+If the storage file is missing, empty, or contains invalid JSON, the file driver treats it as an empty storage bag and overwrites it with valid JSON on the next write.
+
 
 ### Cache Storage Driver
 

--- a/src/Storage/FileStorageDriver.php
+++ b/src/Storage/FileStorageDriver.php
@@ -34,6 +34,9 @@ class FileStorageDriver extends StorageDriver
     {
         try {
             $json = $this->disk->get($this->file);
+            if (blank($json)) {
+                return [];
+            }
 
             /** @phpstan-ignore-next-line */
             return rescue(fn () => json_decode($json, true, flags: JSON_THROW_ON_ERROR), []);

--- a/tests/Unit/Storage/FileStoreDriverTest.php
+++ b/tests/Unit/Storage/FileStoreDriverTest.php
@@ -9,14 +9,19 @@ beforeEach(function () {
     Storage::fake();
 });
 
+function testStorableStorageFile(TestStorable $class): string
+{
+    return (string) Str::of('telegraph')
+        ->append('/', class_basename($class::class))
+        ->append("/", 'foo', '.json');
+}
+
 it('can store and retrieve data', function (string $key, mixed $value) {
     $class = new TestStorable();
 
     $class->storage('file')->set($key, $value);
 
-    $file = Str::of('telegraph')
-        ->append('/', class_basename($class::class))
-        ->append("/", 'foo', '.json');
+    $file = testStorableStorageFile($class);
 
     expect(Storage::exists($file))->toBeTrue();
 
@@ -42,9 +47,7 @@ it('can store and retrieve a model', function () {
 
     $class->storage('file')->set('model', $model);
 
-    $file = Str::of('telegraph')
-        ->append('/', class_basename($class::class))
-        ->append("/", 'foo', '.json');
+    $file = testStorableStorageFile($class);
 
     expect(Storage::exists($file))->toBeTrue();
 
@@ -67,9 +70,7 @@ it('can store and retrieve a nested model', function () {
 
     $class->storage('file')->set('models', $models);
 
-    $file = Str::of('telegraph')
-        ->append('/', class_basename($class::class))
-        ->append("/", 'foo', '.json');
+    $file = testStorableStorageFile($class);
 
     expect(Storage::exists($file))->toBeTrue();
 
@@ -99,3 +100,44 @@ it('can store and retrieve a nested model', function () {
     expect($class->storage('file')->get('models.2'))->toBeInstanceOf(TelegraphChat::class)->id->toBe(3);
     expect($class->storage('file')->get('models.3'))->toBeInstanceOf(TelegraphChat::class)->id->toBe(4);
 });
+
+it('falls back to the default value when the file storage data is missing or empty', function (?string $contents) {
+    $class = new TestStorable();
+    $file = testStorableStorageFile($class);
+
+    if ($contents !== null) {
+        Storage::put($file, $contents);
+    }
+
+    expect($class->storage('file')->get('missing', 'fallback'))->toBe('fallback')
+        ->and($class->storage('file')->get('missing'))->toBeNull();
+})->with([
+    'missing file' => [null],
+    'empty file' => [''],
+    'blank file' => [" \n\t "],
+]);
+
+it('falls back safely when the file storage data is invalid json', function () {
+    $class = new TestStorable();
+    $file = testStorableStorageFile($class);
+
+    Storage::put($file, '{invalid json');
+
+    expect($class->storage('file')->get('missing', 'fallback'))->toBe('fallback');
+});
+
+it('overwrites empty or invalid file storage data with valid json', function (string $contents) {
+    $class = new TestStorable();
+    $file = testStorableStorageFile($class);
+
+    Storage::put($file, $contents);
+
+    $class->storage('file')->set('foo.bar', 'baz');
+
+    expect(json_decode(Storage::get($file), true, flags: JSON_THROW_ON_ERROR))
+        ->toBe(['foo' => ['bar' => 'baz']]);
+})->with([
+    'empty file' => [''],
+    'blank file' => [" \n\t "],
+    'invalid json' => ['{invalid json'],
+]);


### PR DESCRIPTION
## What changed
- Treat missing, empty, whitespace-only, and invalid file storage JSON as an empty storage bag.
- Add regression coverage for missing, empty, invalid storage files and overwrite back to valid JSON.
- Document the file driver fallback behavior.

## Why
FileStorageDriver could attempt to decode an empty storage file, causing a JsonException instead of falling back to empty storage data.

Fixes #378

## Validation
- vendor/bin/pest --colors=always --exclude-group=sandbox tests/Unit/Storage/FileStoreDriverTest.php
- php -l src/Storage/FileStorageDriver.php
- php -l tests/Unit/Storage/FileStoreDriverTest.php
- PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php src/Storage/FileStorageDriver.php tests/Unit/Storage/FileStoreDriverTest.php

Note: composer test:types runs outside the sandbox but currently fails on pre-existing PHPStan issues outside this change.